### PR TITLE
Use boehm GC's pkg-config file.

### DIFF
--- a/run/Makefile
+++ b/run/Makefile
@@ -1,5 +1,5 @@
 cljc : cljc.c Makefile
-	gcc -Wall -g -O0 -o cljc cljc.c -Ilibgc/include -Llibgc/lib -lgc `pkg-config --cflags --libs glib-2.0`
+	gcc -Wall -g -O0 -o cljc cljc.c `pkg-config --cflags bdw-gc` `pkg-config --libs bdw-gc` `pkg-config --cflags --libs glib-2.0`
 
 clean :
 	rm -f cljc


### PR DESCRIPTION
Hi!

The Boehm GC distribution has pkg-config file as well.  I changed Makefile to use it instead of
the hardcoded paths, so system-wide Boehm GC installation can be used.
