### PR TITLE
Stripped down implementation of IHash for several core types. Based on f...

### DIFF
--- a/src/c/preamble.c
+++ b/src/c/preamble.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <stdio.h>
+#include <inttypes.h>
 #include <stdbool.h>
 #include <string.h>
 #include <gc.h>
@@ -11,6 +12,8 @@
 #ifndef MAIN_FUNCTION_NAME
 #define MAIN_FUNCTION_NAME main
 #endif
+
+static uint32_t hashmurmur3_32(const void *data, size_t nbytes);
 
 typedef struct ptable ptable_t;
 
@@ -276,7 +279,7 @@ static value_t* VAR_NAME (cljc_DOT_core_SLASH_count);
 static value_t* VAR_NAME (cljc_DOT_core_SLASH_flatten_tail);
 
 #define ARG_NIL		VAR_NAME (cljc_DOT_core_DOT_List_SLASH_EMPTY)
-#define ARG_CONS(a,d)	FUNCALL2 ((closure_t*)VAR_NAME (cljc_DOT_core_SLASH_Cons), (a), (d))
+#define ARG_CONS(a,d)	FUNCALL3 ((closure_t*)VAR_NAME (cljc_DOT_core_SLASH_Cons), (a), (d), value_nil)
 #define ARG_FIRST(c)	FUNCALL1 ((closure_t*)VAR_NAME (cljc_DOT_core_SLASH_first), (c))
 #define ARG_NEXT(c)	FUNCALL1 ((closure_t*)VAR_NAME (cljc_DOT_core_SLASH_next), (c))
 #define ARG_COUNT(c)	integer_get (FUNCALL1 ((closure_t*)VAR_NAME (cljc_DOT_core_SLASH_count), (c)))
@@ -467,6 +470,16 @@ string_get_utf8 (value_t *v)
 	return s->utf8;
 }
 
+static uint32_t
+string_hash_code(value_t *v)
+{
+        size_t len;
+        string_t *s = (string_t*)v;
+        assert (v->ptable->type == TYPE_String);
+        len = strlen (s->utf8);
+        return hashmurmur3_32(s->utf8, len);
+}
+
 static value_t*
 make_vtable_value (closure_t **vtable)
 {
@@ -542,6 +555,65 @@ truth (value_t *v)
 	if (v == value_false)
 		return false;
 	return true;
+}
+
+
+/**
+ *  MurmurHash3 was created by Austin Appleby  in 2008. The cannonical
+ *  implementations are in C++ and placed in the public.
+ *
+ *    https://sites.google.com/site/murmurhash/
+ *
+ */
+static uint32_t 
+hashmurmur3_32(const void *data, size_t nbytes)
+{
+        if (data == NULL || nbytes == 0) return 0;
+        const uint32_t c1 = 0xcc9e2d51;
+        const uint32_t c2 = 0x1b873593;
+
+        const int nblocks = nbytes / 4;
+        const uint32_t *blocks = (const uint32_t *)(data);
+        const uint8_t *tail = (const uint8_t *)(data + (nblocks * 4));
+
+        uint32_t h = 0;
+
+        int i;
+        uint32_t k;
+        for (i = 0; i < nblocks; i++) {
+                k = blocks[i];
+
+                k *= c1;
+                k = (k << 15) | (k >> (32 - 15));
+                k *= c2;
+
+                h ^= k;
+                h = (h << 13) | (h >> (32 - 13));
+                h = (h * 5) + 0xe6546b64;
+        }
+
+        k = 0;
+        switch (nbytes & 3) {
+                case 3:
+                        k ^= tail[2] << 16;
+                case 2:
+                        k ^= tail[1] << 8;
+                case 1:
+                        k ^= tail[0];
+                        k *= c1;
+                        k = (k << 13) | (k >> (32 - 15));
+                        k *= c2;
+                        h ^= k;
+        };
+
+        h ^= nbytes;
+
+        h ^= h >> 16;
+        h *= 0x85ebca6b;
+        h ^= h >> 13;
+        h *= 0xc2b2ae35;
+        h ^= h >> 16;
+        return h;
 }
 
 static value_t*

--- a/src/clj/cljc/compiler.clj
+++ b/src/clj/cljc/compiler.clj
@@ -312,10 +312,12 @@
 
 (defmethod emit-constant clojure.lang.PersistentList [x]
   (emit-meta-constant x
-		      (emits "FUNCALL2 ((closure_t*)VAR_NAME (cljc_DOT_core_SLASH_Cons), ")
+		      (emits "FUNCALL3 ((closure_t*)VAR_NAME (cljc_DOT_core_SLASH_Cons), ")
 		      (emit-constant (first x))
 		      (emits ", ")
 		      (emit-constant (rest x))
+                      (emits ", ")
+		      (emits "value_nil")
 		      (emits ")")))
 
 (defmethod emit-constant clojure.lang.Cons [x]

--- a/src/clj/cljc/core.clj
+++ b/src/clj/cljc/core.clj
@@ -188,6 +188,9 @@
   ([x y] (bool-expr (list 'c* "make_boolean (integer_get (~{}) >= integer_get (~{}))" x y)))
   ([x y & more] `(and (>= ~x ~y) (>= ~y ~@more))))
 
+(defmacro mod [num div]
+  (list 'c* "make_integer (integer_get(~{}) % integer_get(~{}))" num div))
+
 (defmacro bit-not [x]
   (list 'c* "make_integer (~ (integer_get (~{})))" x))
 
@@ -247,6 +250,14 @@
   ;; FIXME: see bit-clear
   (list 'c* "make_integer (integer_get (~{}) | (1ul << integer_get (~{})))" x n))
 
+;; internal
+(defmacro caching-hash [coll hash-fn hash-key]
+  `(let [h# ~hash-key]
+     (if-not (nil? h#)
+       h#
+       (let [h# (~hash-fn ~coll)]
+         (set! ~hash-key h#)
+         h#))))
 
 (defmacro ^{:private true} assert-args [fnname & pairs]
   `(do (when-not ~(first pairs)

--- a/src/cljc/cljc/core.cljc
+++ b/src/cljc/cljc/core.cljc
@@ -108,6 +108,9 @@
 (defprotocol IEquiv
   (-equiv [o other]))
 
+(defprotocol IHash
+  (-hash [o]))
+
 (defprotocol ISeqable
   (-seq [o]))
 
@@ -172,9 +175,9 @@
 (defprotocol IChunkedNext
   (-chunked-next [coll]))
 
-(declare pr-sequential pr-seq list cons inc equiv-sequential)
+(declare pr-sequential pr-seq list hash-coll cons inc equiv-sequential)
 
-(deftype Cons [first rest]
+(deftype Cons [first rest ^:mutable __hash]
   ASeq
   ISeq
   (-first [coll] first)
@@ -191,7 +194,11 @@
   (-seq [coll] coll)
 
   ICollection
-  (-conj [coll o] (Cons o coll))
+  (-conj [coll o] (Cons o coll nil))
+
+  IHash
+  (-hash [coll]
+    (caching-hash coll hash-coll __hash))
 
   IPrintable
   (-pr-seq [coll opts] (pr-sequential pr-seq "(" " " ")" opts coll)))
@@ -208,7 +215,7 @@
   (-seq [coll] nil)
 
   ICollection
-  (-conj [coll o] (Cons o nil))
+  (-conj [coll o] (Cons o nil nil))
 
   ISequential
   IEquiv
@@ -216,6 +223,9 @@
 
   ICounted
   (-count [_] 0)
+
+  IHash
+  (-hash [coll] 0)
 
   IPrintable
   (-pr-seq [coll opts] (list "()")))
@@ -304,6 +314,9 @@
   ISet
   (-disjoin [_ v] nil)
 
+  IHash
+  (-hash [o] 0)
+
   IPrintable
   (-pr-seq [o opts] (list "nil")))
 
@@ -313,10 +326,17 @@
     (and (has-type? o Integer)
          (c* "make_boolean (integer_get (~{}) == integer_get (~{}))" i o)))
 
+  IHash
+  (-hash [o] o)
+
   IPrintable
   (-pr-seq [i opts] (list (c* "make_string_copy_free (g_strdup_printf (\"%ld\", integer_get (~{})))" i))))
 
 (extend-type Boolean
+  IHash
+  (-hash [o]
+    (if (identical? o true) 1 0))
+
   IPrintable
   (-pr-seq [o opts] (list (if o "true" "false"))))
 
@@ -416,6 +436,10 @@ reduces them without incurring seq initialization"
     (and (has-type? o Character)
          (c* "make_boolean (character_get (~{}) == character_get (~{}))" c o)))
 
+  IHash
+  (-hash [c]
+    (c* "make_integer (character_get (~{}))" c))
+
   IPrintable
   (-pr-seq [c opts]
     (list "\\" (c* "make_string_from_unichar (character_get (~{}))" c))))
@@ -426,6 +450,10 @@ reduces them without incurring seq initialization"
     (and (has-type? o String)
          ;; FIXME: normalize first
          (c* "make_boolean (strcmp (string_get_utf8 (~{}), string_get_utf8 (~{})) == 0)" s o)))
+
+  IHash
+  (-hash [s]
+    (c* "make_integer (string_hash_code(~{}))" s))
 
   ISeqable
   (-seq [string] (prim-seq string 0))
@@ -614,6 +642,11 @@ reduces them without incurring seq initialization"
   ([x y] (if (< x y) x y))
   ([x y & more]
      (reduce min (min x y) more)))
+
+(defn mod
+  "Modulus of num and div. Truncates toward negative infinity."
+  [n d]
+  (cljc.core/mod n d))
 
 (defn ^boolean pos?
   "Returns true if num is greater than zero, else false"
@@ -806,8 +839,8 @@ reduces them without incurring seq initialization"
   [x coll]
   (if (or (nil? coll)
           (satisfies? ISeq coll))
-    (Cons x coll)
-    (Cons x (seq coll))))
+    (Cons x coll nil)
+    (Cons x (seq coll) nil)))
 
 (defn get
   "Returns the value mapped to key, not-found or nil if key not present."
@@ -852,6 +885,18 @@ reduces them without incurring seq initialization"
              (nil? ys) false
              (= (first xs) (first ys)) (recur (next xs) (next ys))
              true false)))))
+
+(defn hash [o]
+  (-hash o))
+
+(defn hash-combine [seed hash]
+  ; a la boost
+  (bit-xor seed (+ hash 0x9e3779b9
+                   (bit-shift-left seed 6)
+                   (bit-shift-right seed 2))))
+
+(defn- hash-coll [coll]
+  (reduce #(hash-combine %1 (-hash %2)) (-hash (first coll)) (next coll)))
 
 (defn ^boolean every?
   "Returns true if (pred x) is logical true for every x in coll, else
@@ -1093,7 +1138,7 @@ reduces them without incurring seq initialization"
   (-seq [coll] coll)
 
   ICollection
-  (-conj [coll o] (Cons o coll))
+  (-conj [coll o] (Cons o coll nil))
 
   IPrintable
   (-pr-seq [coll opts]

--- a/test/clojurec/core_test.clj
+++ b/test/clojurec/core_test.clj
@@ -194,7 +194,7 @@
 
 (deftest core
   (testing "cljc.core"
-    (is (= (core-run '(let [c (Cons 1 2)]
+    (is (= (core-run '(let [c (Cons 1 2 nil)]
 			(print (. c -first))
 			(print (. c -rest))))
 	   [1 2]))
@@ -329,6 +329,18 @@
     (is (= (core-run '(pr (= '(1 2 3) '(1 2 3))
                           (= '(nil nil nil) (seq (make-array 3)))))
            [true true]))))
+
+(deftest hashing
+  (testing "object hashing"
+    (is (= (core-run '(pr (= (-hash \a) 97)))  [true]))
+    (is (= (core-run '(pr (= (-hash 2354) 2354)))  [true]))
+    (is (= (core-run '(pr (= (-hash nil) 0)))  [true]))
+    (is (= (core-run '(pr (= (-hash '()) 0)))  [true]))
+    (is (= (core-run '(pr (= (-hash false) 0)))  [true]))
+    (is (= (core-run '(pr (= (-hash true) 1)))  [true]))
+    (is (= (core-run '(pr (= (-hash 0) 0)))  [true]))
+    (is (= (core-run '(pr (= (-hash "") 0)))  [true]))))
+
 
 (deftest sets
   (testing "sets"


### PR DESCRIPTION
...eedback from Mark Probst: Removed generic hash fn capabilities for now. Switched string hashing to use MurmurHash3 instead of hash based on Java's string hashing algorithm.
