### PR TITLE
Fix sample build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you do the following in the `clojurec` directory
     lein run -c samples/echo.cljc cljc.user run run
 	lein run -d cljc.user/-main run
     cd run
-    make
+    make -f c/Makefile
 
 you should have a `cljc` executable in the `run` directory that acts mostly like `echo`.
 


### PR DESCRIPTION
The makefile is actually in `run/c/Makefile`, but indeed should be invoked with `run/` as cwd.

(This change has already been made on the Wiki.)